### PR TITLE
[fix/experience-null-check] Null-check on response of experiences endpont

### DIFF
--- a/qubit-sdk/src/main/java/com/qubit/android/sdk/internal/experience/interactor/ExperienceInteractorImpl.kt
+++ b/qubit-sdk/src/main/java/com/qubit/android/sdk/internal/experience/interactor/ExperienceInteractorImpl.kt
@@ -54,11 +54,12 @@ internal class ExperienceInteractorImpl(
 
   private fun mapExperienceData(experienceIdList: List<Int>, experienceModel: ExperienceModel): List<Experience> =
       experienceModel.experiencePayloads
-          .filter { experienceIdList.isEmpty() || experienceIdList.contains(it.id) }
-          .map {
+          ?.filter { experienceIdList.isEmpty() || experienceIdList.contains(it.id) }
+          ?.map {
             val callbackConnector: CallbackConnector = CallbackConnectorImpl(it.callback, deviceId)
             ExperienceImpl(it, callbackConnector)
           }
+          ?: emptyList()
 
   private fun getExperienceApi(): String =
       experienceService.configuration?.experienceApiHost ?: getDefaultExperienceApiHost()

--- a/qubit-sdk/src/main/java/com/qubit/android/sdk/internal/experience/model/ExperienceModel.kt
+++ b/qubit-sdk/src/main/java/com/qubit/android/sdk/internal/experience/model/ExperienceModel.kt
@@ -1,3 +1,3 @@
 package com.qubit.android.sdk.internal.experience.model
 
-data class ExperienceModel(val experiencePayloads: List<ExperiencePayload>)
+data class ExperienceModel(val experiencePayloads: List<ExperiencePayload>?)

--- a/qubit-sdk/src/test/java/com/qubit/android/sdk/internal/experience/interactor/ExperienceInteractorImplTest.kt
+++ b/qubit-sdk/src/test/java/com/qubit/android/sdk/internal/experience/interactor/ExperienceInteractorImplTest.kt
@@ -1,5 +1,6 @@
 package com.qubit.android.sdk.internal.experience.interactor
 
+import com.google.gson.JsonObject
 import com.qubit.android.BaseTest
 import com.qubit.android.sdk.api.tracker.OnExperienceError
 import com.qubit.android.sdk.api.tracker.OnExperienceSuccess
@@ -9,7 +10,6 @@ import com.qubit.android.sdk.internal.experience.connector.ExperienceConnectorBu
 import com.qubit.android.sdk.internal.experience.model.ExperienceModel
 import com.qubit.android.sdk.internal.experience.model.ExperiencePayload
 import com.qubit.android.sdk.internal.experience.service.ExperienceService
-import org.json.JSONObject
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.*
@@ -63,9 +63,9 @@ class ExperienceInteractorImplTest : BaseTest() {
     val mockCallbackUrl = "https://www.somewebside.com"
 
     val experienceMockList = arrayListOf(
-        ExperiencePayload(JSONObject(), false, 139731, mockCallbackUrl, 75834),
-        ExperiencePayload(JSONObject(), false, 143401, mockCallbackUrl, 855620),
-        ExperiencePayload(JSONObject(), true, 143640, mockCallbackUrl, 852185)
+        ExperiencePayload(JsonObject(), false, 139731, mockCallbackUrl, 75834),
+        ExperiencePayload(JsonObject(), false, 143401, mockCallbackUrl, 855620),
+        ExperiencePayload(JsonObject(), true, 143640, mockCallbackUrl, 852185)
     )
 
     return ExperienceModel(experienceMockList)


### PR DESCRIPTION
Up to now, there was an assumption that response of /experiences endpoint always contains value of 'experiencePayloads' property, even if there are no experiences.
It is the most probable reason of crash reported by client.
Now, experiences connector is prepared for receiving null value and treats it as empty array.